### PR TITLE
Removing the creation of a file

### DIFF
--- a/lib/beaker/i18n_helper.rb
+++ b/lib/beaker/i18n_helper.rb
@@ -27,8 +27,6 @@ module Beaker::I18nHelper
     Array(hsts).each do |host|
       on(host, "localectl set-locale LANG=#{lang}.utf8")
       on(host, "export LANGUAGE=#{lang}.utf8")
-      on(host, "mkdir /opt/puppetlabs/puppet/share/locale/ja")
-      on(host, "touch /opt/puppetlabs/puppet/share/locale/ja/puppet.po")
     end
   end
 end


### PR DESCRIPTION
This has been moved to spec_helper_acceptance as it only needs to happen
once and can be removed at a later date. Currently it is only a work around.